### PR TITLE
Fix a compile error with modern rclcpp.

### DIFF
--- a/include/message_tf_frame_transformer/MessageTfFrameTransformer.ros2.hpp
+++ b/include/message_tf_frame_transformer/MessageTfFrameTransformer.ros2.hpp
@@ -66,7 +66,7 @@ class MessageTfFrameTransformer : public rclcpp::Node {
 
   void detectMessageType();
 
-  void transformGeneric(const std::shared_ptr<rclcpp::SerializedMessage>& serialized_msg);
+  void transformGeneric(const std::shared_ptr<const rclcpp::SerializedMessage>& serialized_msg);
 
   template <typename T>
   void transform(const T& msg);
@@ -98,7 +98,7 @@ class MessageTfFrameTransformer : public rclcpp::Node {
   rclcpp::TimerBase::SharedPtr detect_message_type_timer_;
 
   rclcpp::GenericSubscription::SharedPtr subscriber_;
-  
+
   rclcpp::PublisherBase::SharedPtr publisher_;
 
   std::string msg_type_;

--- a/src/MessageTfFrameTransformer.ros2.cpp
+++ b/src/MessageTfFrameTransformer.ros2.cpp
@@ -138,7 +138,7 @@ void MessageTfFrameTransformer::detectMessageType() {
 }
 
 
-void MessageTfFrameTransformer::transformGeneric(const std::shared_ptr<rclcpp::SerializedMessage>& serialized_msg) {
+void MessageTfFrameTransformer::transformGeneric(const std::shared_ptr<const rclcpp::SerializedMessage>& serialized_msg) {
 
   if (false) {}
 #define MESSAGE_TYPE(TYPE, NAME)                                               \


### PR DESCRIPTION
In particular, the constref shared_ptr callback
signature must also have a 'const' on the type.

Note that I compile-tested this on Humble (Ubuntu 22.04), Iron (Ubuntu 22.04) and Rolling (Ubuntu 24.04), and it now seems to compile on all of them.

I believe this should fix #2 